### PR TITLE
Add JIT for `hash?`, `syntax?`, `syntax-e`, `char<?` (etc).

### DIFF
--- a/racket/src/racket/src/char.c
+++ b/racket/src/racket/src/char.c
@@ -120,10 +120,22 @@ void scheme_init_char (Scheme_Startup_Env *env)
   SCHEME_PRIM_PROC_FLAGS(p) |= scheme_intern_prim_opt_flags(SCHEME_PRIM_IS_BINARY_INLINED);
   scheme_addto_prim_instance("char=?", p, env);
 
-  ADD_FOLDING_PRIM("char<?",                char_lt,               2, -1, 1, env);
-  ADD_FOLDING_PRIM("char>?",                char_gt,               2, -1, 1, env);
-  ADD_FOLDING_PRIM("char<=?",               char_lt_eq,            2, -1, 1, env);
-  ADD_FOLDING_PRIM("char>=?",               char_gt_eq,            2, -1, 1, env);
+  p = scheme_make_folding_prim(char_lt, "char<?", 2, -1, 1);
+  SCHEME_PRIM_PROC_FLAGS(p) |= scheme_intern_prim_opt_flags(SCHEME_PRIM_IS_BINARY_INLINED);
+  scheme_addto_prim_instance("char<?", p, env);
+
+  p = scheme_make_folding_prim(char_gt, "char>?", 2, -1, 1);
+  SCHEME_PRIM_PROC_FLAGS(p) |= scheme_intern_prim_opt_flags(SCHEME_PRIM_IS_BINARY_INLINED);
+  scheme_addto_prim_instance("char>?", p, env);
+
+  p = scheme_make_folding_prim(char_lt_eq, "char<=?", 2, -1, 1);
+  SCHEME_PRIM_PROC_FLAGS(p) |= scheme_intern_prim_opt_flags(SCHEME_PRIM_IS_BINARY_INLINED);
+  scheme_addto_prim_instance("char<=?", p, env);
+
+  p = scheme_make_folding_prim(char_gt_eq, "char>=?", 2, -1, 1);
+  SCHEME_PRIM_PROC_FLAGS(p) |= scheme_intern_prim_opt_flags(SCHEME_PRIM_IS_BINARY_INLINED);
+  scheme_addto_prim_instance("char>=?", p, env);
+
   ADD_FOLDING_PRIM("char-ci=?",             char_eq_ci,            2, -1, 1, env);
   ADD_FOLDING_PRIM("char-ci<?",             char_lt_ci,            2, -1, 1, env);
   ADD_FOLDING_PRIM("char-ci>?",             char_gt_ci,            2, -1, 1, env);

--- a/racket/src/racket/src/jit.h
+++ b/racket/src/racket/src/jit.h
@@ -303,6 +303,7 @@ struct scheme_jit_common_record {
   void *bad_cXr_code;
   void *bad_mcar_code, *bad_mcdr_code;
   void *bad_set_mcar_code, *bad_set_mcdr_code;
+  void *bad_syntax_e_code;
   void *imag_part_code, *real_part_code, *make_rectangular_code;
   void *bad_flimag_part_code, *bad_flreal_part_code, *bad_make_flrectangular_code;
   void *unbox_code, *set_box_code, *box_cas_fail_code;

--- a/racket/src/racket/src/jit_ts.c
+++ b/racket/src/racket/src/jit_ts.c
@@ -75,6 +75,7 @@ define_ts_iS_s(scheme_checked_byte_string_ref, FSRC_MARKS)
 define_ts_iS_s(scheme_checked_byte_string_set, FSRC_MARKS)
 define_ts_iS_s(scheme_checked_flvector_ref, FSRC_MARKS)
 define_ts_iS_s(scheme_checked_flvector_set, FSRC_MARKS)
+define_ts_iS_s(scheme_syntax_e, FSRC_MARKS)
 #ifdef MZ_LONG_DOUBLE
 define_ts_iS_s(scheme_checked_extflvector_ref, FSRC_MARKS)
 define_ts_iS_s(scheme_checked_extflvector_set, FSRC_MARKS)

--- a/racket/src/racket/src/jit_ts.c
+++ b/racket/src/racket/src/jit_ts.c
@@ -75,7 +75,7 @@ define_ts_iS_s(scheme_checked_byte_string_ref, FSRC_MARKS)
 define_ts_iS_s(scheme_checked_byte_string_set, FSRC_MARKS)
 define_ts_iS_s(scheme_checked_flvector_ref, FSRC_MARKS)
 define_ts_iS_s(scheme_checked_flvector_set, FSRC_MARKS)
-define_ts_iS_s(scheme_syntax_e, FSRC_MARKS)
+define_ts_iS_s(scheme_checked_syntax_e, FSRC_MARKS)
 #ifdef MZ_LONG_DOUBLE
 define_ts_iS_s(scheme_checked_extflvector_ref, FSRC_MARKS)
 define_ts_iS_s(scheme_checked_extflvector_set, FSRC_MARKS)

--- a/racket/src/racket/src/jitcommon.c
+++ b/racket/src/racket/src/jitcommon.c
@@ -398,7 +398,7 @@ static int common1(mz_jit_state *jitter, void *_data)
       (void)mz_finish_lwe(ts_apply_prim_to_fail, ref);
       break;
     case 13:
-      (void)mz_finish_lwe(ts_scheme_syntax_e, ref);
+      (void)mz_finish_lwe(ts_scheme_checked_syntax_e, ref);
       break;
     }
     CHECK_LIMIT();

--- a/racket/src/racket/src/jitcommon.c
+++ b/racket/src/racket/src/jitcommon.c
@@ -290,7 +290,7 @@ static int common1(mz_jit_state *jitter, void *_data)
 
   /* *** [bad_][m]{car,cdr,...,{imag,real}_part}_code *** */
   /* Argument is in R2 for cXX+r, R0 otherwise */
-  for (i = 0; i < 13; i++) {
+  for (i = 0; i < 14; i++) {
     void *code;
     
     code = jit_get_ip();
@@ -333,6 +333,9 @@ static int common1(mz_jit_state *jitter, void *_data)
       break;
     case 12:
       sjc.bad_cXr_code = code;
+      break;
+    case 13:
+      sjc.bad_syntax_e_code = code;
       break;
     }
     mz_prolog(JIT_R1);
@@ -393,6 +396,9 @@ static int common1(mz_jit_state *jitter, void *_data)
       break;
     case 12:
       (void)mz_finish_lwe(ts_apply_prim_to_fail, ref);
+      break;
+    case 13:
+      (void)mz_finish_lwe(ts_scheme_syntax_e, ref);
       break;
     }
     CHECK_LIMIT();

--- a/racket/src/racket/src/jitinline.c
+++ b/racket/src/racket/src/jitinline.c
@@ -272,6 +272,7 @@ static int generate_inlined_constant_test(mz_jit_state *jitter, Scheme_App2_Rec 
   return 1;
 }
 
+/* -1 for can_chaperone for `chaperone?` test */
 static int generate_inlined_type_test(mz_jit_state *jitter, Scheme_App2_Rec *app,
 				      Scheme_Type lo_ty, Scheme_Type hi_ty, int can_chaperone,
 				      Branch_Info *for_branch, int branch_short,
@@ -1283,6 +1284,12 @@ int scheme_generate_inlined_unary(mz_jit_state *jitter, Scheme_App2_Rec *app, in
   } else if (IS_NAMED_PRIM(rator, "path?")) {
     generate_inlined_type_test(jitter, app, SCHEME_PLATFORM_PATH_KIND, SCHEME_PLATFORM_PATH_KIND, 0, for_branch, branch_short, dest);
     return 1;
+  } else if (IS_NAMED_PRIM(rator, "hash?")) {
+    generate_inlined_type_test(jitter, app, scheme_hash_table_type, scheme_hash_tree_indirection_type, 1, for_branch, branch_short, dest);
+    return 1;
+  } else if (IS_NAMED_PRIM(rator, "syntax?")) {
+    generate_inlined_type_test(jitter, app, scheme_primitive_syntax_type, scheme_primitive_syntax_type, 0, for_branch, branch_short, dest);
+    return 1;
   } else if (IS_NAMED_PRIM(rator, "eof-object?")) {
     generate_inlined_constant_test(jitter, app, scheme_eof, NULL, for_branch, branch_short, dest);
     return 1;
@@ -1598,6 +1605,36 @@ int scheme_generate_inlined_unary(mz_jit_state *jitter, Scheme_App2_Rec *app, in
       mz_rs_sync();
       (void)jit_calli(sjc.list_length_code);
       jit_movr_p(dest, JIT_R0);
+
+      return 1;
+    } else if (IS_NAMED_PRIM(rator, "syntax-e")) {
+      GC_CAN_IGNORE jit_insn *reffail = NULL, *ref;
+
+      LOG_IT("inlined syntax-e\n");
+
+      mz_runstack_skipped(jitter, 1);
+
+      scheme_generate_non_tail(app->rand, jitter, 0, 1, 0);
+      CHECK_LIMIT();
+
+      mz_runstack_unskipped(jitter, 1);
+
+      mz_rs_sync_fail_branch();
+
+      __START_TINY_JUMPS__(1);
+
+      ref = jit_bmci_ul(jit_forward(), JIT_R0, 0x1);
+      reffail = jit_get_ip();
+      __END_TINY_JUMPS__(1);
+      (void)jit_calli(sjc.bad_syntax_e_code);
+      __START_TINY_JUMPS__(1);
+      mz_patch_branch(ref);
+      (void)mz_bnei_t(reffail, JIT_R0, scheme_primitive_syntax_type, JIT_R1);
+      /* FIXME: do we have to care about scheme_delay_syntax_type ?*/
+      (void)jit_ldxi_p(dest, JIT_R0, &(SCHEME_STX_VAL((Scheme_Stx *)0x0)));
+      VALIDATE_RESULT(dest);
+      CHECK_LIMIT();
+      __END_TINY_JUMPS__(1);
 
       return 1;
     } else if (IS_NAMED_PRIM(rator, "vector-length")
@@ -2461,7 +2498,7 @@ int scheme_generate_two_args(Scheme_Object *rand1, Scheme_Object *rand2, mz_jit_
   return direction;
 }
 
-static int generate_binary_char(mz_jit_state *jitter, Scheme_App3_Rec *app,
+static int generate_binary_char(mz_jit_state *jitter, Scheme_App3_Rec *app, int cmp,
                                 Branch_Info *for_branch, int branch_short, int dest)
 /* de-sync'd ok */
 {
@@ -2532,9 +2569,47 @@ static int generate_binary_char(mz_jit_state *jitter, Scheme_App3_Rec *app,
     /* Extract character value */
     jit_ldxi_i(JIT_R0, JIT_R0, (intptr_t)&SCHEME_CHAR_VAL((Scheme_Object *)0x0));
     jit_ldxi_i(JIT_R1, JIT_R1, (intptr_t)&SCHEME_CHAR_VAL((Scheme_Object *)0x0));
-    ref = jit_bner_i(jit_forward(), JIT_R0, JIT_R1);
+
+    /* FIXME: why are these tests all inverted? */
+    switch (cmp) {
+    case CMP_EQUAL:
+      ref = jit_bner_i(jit_forward(), JIT_R0, JIT_R1);
+      break;
+    case CMP_LEQ:
+      ref = jit_bgtr_i(jit_forward(), JIT_R0, JIT_R1);
+      break;
+    case CMP_GEQ:
+      ref = jit_bltr_i(jit_forward(), JIT_R0, JIT_R1);
+      break;
+    case CMP_GT:
+      ref = jit_bler_i(jit_forward(), JIT_R0, JIT_R1);
+      break;
+    case CMP_LT:
+      ref = jit_bger_i(jit_forward(), JIT_R0, JIT_R1);
+      break;
+    default:
+      ref = NULL; /* never happens */
+    }
   } else {
-    ref = jit_bner_p(jit_forward(), JIT_R0, JIT_R1);
+    switch(cmp) {
+    case CMP_EQUAL:
+      ref = jit_bner_p(jit_forward(), JIT_R0, JIT_R1);
+      break;
+    case CMP_LEQ:
+      ref = jit_bgtr_p(jit_forward(), JIT_R0, JIT_R1);
+      break;
+    case CMP_GEQ:
+      ref = jit_bltr_p(jit_forward(), JIT_R0, JIT_R1);
+      break;
+    case CMP_GT:
+      ref = jit_bler_p(jit_forward(), JIT_R0, JIT_R1);
+      break;
+    case CMP_LT:
+      ref = jit_bger_p(jit_forward(), JIT_R0, JIT_R1);
+      break;
+    default:
+      ref = NULL; /* never happens */
+    }
   }
   CHECK_LIMIT();
   if (for_branch) {
@@ -3294,7 +3369,19 @@ int scheme_generate_inlined_binary(mz_jit_state *jitter, Scheme_App3_Rec *app, i
     scheme_generate_arith(jitter, rator, app->rand1, app->rand2, 2, 0, CMP_BIT, 0, for_branch, branch_short, 0, 0, NULL, dest);
     return 1;
   } else if (IS_NAMED_PRIM(rator, "char=?")) {
-    generate_binary_char(jitter, app, for_branch, branch_short, dest);
+    generate_binary_char(jitter, app, CMP_EQUAL, for_branch, branch_short, dest);
+    return 1;
+  } else if (IS_NAMED_PRIM(rator, "char<=?")) {
+    generate_binary_char(jitter, app, CMP_LEQ, for_branch, branch_short, dest);
+    return 1;
+  } else if (IS_NAMED_PRIM(rator, "char>=?")) {
+    generate_binary_char(jitter, app, CMP_GEQ, for_branch, branch_short, dest);
+    return 1;
+  } else if (IS_NAMED_PRIM(rator, "char>?")) {
+    generate_binary_char(jitter, app, CMP_GT, for_branch, branch_short, dest);
+    return 1;
+  } else if (IS_NAMED_PRIM(rator, "char<?")) {
+    generate_binary_char(jitter, app, CMP_LT, for_branch, branch_short, dest);
     return 1;
   } else if (!for_branch) {
     if (IS_NAMED_PRIM(rator, "+")) {

--- a/racket/src/racket/src/jitinline.c
+++ b/racket/src/racket/src/jitinline.c
@@ -1285,10 +1285,10 @@ int scheme_generate_inlined_unary(mz_jit_state *jitter, Scheme_App2_Rec *app, in
     generate_inlined_type_test(jitter, app, SCHEME_PLATFORM_PATH_KIND, SCHEME_PLATFORM_PATH_KIND, 0, for_branch, branch_short, dest);
     return 1;
   } else if (IS_NAMED_PRIM(rator, "hash?")) {
-    generate_inlined_type_test(jitter, app, scheme_hash_table_type, scheme_hash_tree_indirection_type, 1, for_branch, branch_short, dest);
+    generate_inlined_type_test(jitter, app, scheme_hash_table_type, scheme_bucket_table_type, 1, for_branch, branch_short, dest);
     return 1;
   } else if (IS_NAMED_PRIM(rator, "syntax?")) {
-    generate_inlined_type_test(jitter, app, scheme_primitive_syntax_type, scheme_primitive_syntax_type, 0, for_branch, branch_short, dest);
+    generate_inlined_type_test(jitter, app, scheme_stx_type, scheme_stx_type, 0, for_branch, branch_short, dest);
     return 1;
   } else if (IS_NAMED_PRIM(rator, "eof-object?")) {
     generate_inlined_constant_test(jitter, app, scheme_eof, NULL, for_branch, branch_short, dest);
@@ -1630,7 +1630,6 @@ int scheme_generate_inlined_unary(mz_jit_state *jitter, Scheme_App2_Rec *app, in
       __START_TINY_JUMPS__(1);
       mz_patch_branch(ref);
       (void)mz_bnei_t(reffail, JIT_R0, scheme_primitive_syntax_type, JIT_R1);
-      /* FIXME: do we have to care about scheme_delay_syntax_type ?*/
       (void)jit_ldxi_p(dest, JIT_R0, &(SCHEME_STX_VAL((Scheme_Stx *)0x0)));
       VALIDATE_RESULT(dest);
       CHECK_LIMIT();
@@ -2570,7 +2569,6 @@ static int generate_binary_char(mz_jit_state *jitter, Scheme_App3_Rec *app, int 
     jit_ldxi_i(JIT_R0, JIT_R0, (intptr_t)&SCHEME_CHAR_VAL((Scheme_Object *)0x0));
     jit_ldxi_i(JIT_R1, JIT_R1, (intptr_t)&SCHEME_CHAR_VAL((Scheme_Object *)0x0));
 
-    /* FIXME: why are these tests all inverted? */
     switch (cmp) {
     case CMP_EQUAL:
       ref = jit_bner_i(jit_forward(), JIT_R0, JIT_R1);

--- a/racket/src/racket/src/list.c
+++ b/racket/src/racket/src/list.c
@@ -567,11 +567,13 @@ scheme_init_list (Scheme_Startup_Env *env)
   SCHEME_PRIM_PROC_FLAGS(p) |= scheme_intern_prim_opt_flags(SCHEME_PRIM_IS_OMITABLE_ALLOCATION);
   scheme_addto_prim_instance("hasheqv", p, env);
   
-  scheme_addto_prim_instance("hash?",
-			     scheme_make_folding_prim(hash_p,
-						      "hash?",
-						      1, 1, 1),
-			     env);
+  REGISTER_SO(hash_p);
+  p = scheme_make_folding_prim(hash_p, "hash?", 1, 1, 1);
+  SCHEME_PRIM_PROC_FLAGS(p) |= scheme_intern_prim_opt_flags(SCHEME_PRIM_IS_UNARY_INLINED
+                                                            | SCHEME_PRIM_IS_OMITABLE);
+  scheme_addto_prim_instance ("hash?", p, env);
+
+
   scheme_addto_prim_instance("hash-eq?",
 			     scheme_make_folding_prim(scheme_hash_eq_p,
 						      "hash-eq?",

--- a/racket/src/racket/src/schpriv.h
+++ b/racket/src/racket/src/schpriv.h
@@ -1240,6 +1240,8 @@ Scheme_Object *scheme_datum_to_syntax(Scheme_Object *o, Scheme_Object *stx_src, 
 
 Scheme_Object *scheme_syntax_to_datum(Scheme_Object *stx);
 
+Scheme_Object *scheme_syntax_e(int argc, Scheme_Object **argv);
+
 Scheme_Object *scheme_stx_property(Scheme_Object *_stx,
 				   Scheme_Object *key,
 				   Scheme_Object *val);

--- a/racket/src/racket/src/schpriv.h
+++ b/racket/src/racket/src/schpriv.h
@@ -1240,7 +1240,7 @@ Scheme_Object *scheme_datum_to_syntax(Scheme_Object *o, Scheme_Object *stx_src, 
 
 Scheme_Object *scheme_syntax_to_datum(Scheme_Object *stx);
 
-Scheme_Object *scheme_syntax_e(int argc, Scheme_Object **argv);
+Scheme_Object *scheme_checked_syntax_e(int argc, Scheme_Object **argv);
 
 Scheme_Object *scheme_stx_property(Scheme_Object *_stx,
 				   Scheme_Object *key,

--- a/racket/src/racket/src/stypes.h
+++ b/racket/src/racket/src/stypes.h
@@ -108,6 +108,9 @@ enum {
   scheme_thread_type,                   /* 75 */
   scheme_cont_mark_set_type,            /* 76 */
   scheme_sema_type,                     /* 77 */
+
+  /* hash table types (must be together for hash?
+   * implementation */
   scheme_hash_table_type,               /* 78 */
   scheme_hash_tree_type,                /* 79 */
   scheme_eq_hash_tree_type,             /* 80 */
@@ -115,23 +118,24 @@ enum {
   scheme_hash_tree_subtree_type,        /* 82 */
   scheme_hash_tree_collision_type,      /* 83 */
   scheme_hash_tree_indirection_type,    /* 84 */
-  scheme_cpointer_type,                 /* 85 */
-  scheme_prefix_type,                   /* 86 */
-  scheme_weak_box_type,                 /* 87 */
-  scheme_ephemeron_type,                /* 88 */
-  scheme_struct_type_type,              /* 89 */
-  scheme_set_macro_type,                /* 90 */
-  scheme_listener_type,                 /* 91 */
-  scheme_env_type,                      /* 92 */
-  scheme_startup_env_type,              /* 93 */
-  scheme_config_type,                   /* 94 */
-  scheme_stx_type,                      /* 95 */
-  scheme_will_executor_type,            /* 96 */
-  scheme_custodian_type,                /* 97 */
-  scheme_random_state_type,             /* 98 */
-  scheme_regexp_type,                   /* 99 */
-  scheme_bucket_type,                   /* 100 */
-  scheme_bucket_table_type,             /* 101 */
+  scheme_bucket_type,                   /* 85 */
+  scheme_bucket_table_type,             /* 86 */
+
+  scheme_cpointer_type,                 /* 87 */
+  scheme_prefix_type,                   /* 88 */
+  scheme_weak_box_type,                 /* 89 */
+  scheme_ephemeron_type,                /* 90 */
+  scheme_struct_type_type,              /* 91 */
+  scheme_set_macro_type,                /* 92 */
+  scheme_listener_type,                 /* 93 */
+  scheme_env_type,                      /* 94 */
+  scheme_startup_env_type,              /* 95 */
+  scheme_config_type,                   /* 96 */
+  scheme_stx_type,                      /* 97 */
+  scheme_will_executor_type,            /* 98 */
+  scheme_custodian_type,                /* 99 */
+  scheme_random_state_type,             /* 100 */
+  scheme_regexp_type,                   /* 101 */
   scheme_subprocess_type,               /* 102 */
   scheme_eval_waiting_type,             /* 103 */
   scheme_tail_call_waiting_type,        /* 104 */

--- a/racket/src/racket/src/syntax.c
+++ b/racket/src/racket/src/syntax.c
@@ -43,7 +43,7 @@ static Scheme_Object *syntax_p(int argc, Scheme_Object **argv);
 static Scheme_Object *syntax_to_datum(int argc, Scheme_Object **argv);
 static Scheme_Object *datum_to_syntax(int argc, Scheme_Object **argv);
 
-Scheme_Object *scheme_syntax_e(int argc, Scheme_Object **argv);
+Scheme_Object *scheme_checked_syntax_e(int argc, Scheme_Object **argv);
 static Scheme_Object *syntax_line(int argc, Scheme_Object **argv);
 static Scheme_Object *syntax_col(int argc, Scheme_Object **argv);
 static Scheme_Object *syntax_pos(int argc, Scheme_Object **argv);
@@ -107,7 +107,10 @@ void scheme_init_stx(Scheme_Startup_Env *env)
   ADD_FOLDING_PRIM("syntax->datum", syntax_to_datum, 1, 1, 1, env);
   ADD_IMMED_PRIM("datum->syntax", datum_to_syntax, 2, 5, env);
   
-  ADD_FOLDING_PRIM("syntax-e", scheme_syntax_e, 1, 1, 1, env);
+  REGISTER_SO(scheme_checked_syntax_e);
+  o = scheme_make_folding_prim(scheme_checked_syntax_e, "syntax-e", 1, 1, 1);
+  SCHEME_PRIM_PROC_FLAGS(o) |= scheme_intern_prim_opt_flags(SCHEME_PRIM_IS_UNARY_INLINED);
+  scheme_addto_prim_instance("syntax-e", o, env);
 
   ADD_FOLDING_PRIM("syntax-line"    , syntax_line   , 1, 1, 1, env);
   ADD_FOLDING_PRIM("syntax-column"  , syntax_col    , 1, 1, 1, env);
@@ -777,7 +780,7 @@ static Scheme_Object *datum_to_syntax(int argc, Scheme_Object **argv)
   return src;
 }
 
-Scheme_Object *scheme_syntax_e(int argc, Scheme_Object **argv)
+Scheme_Object *scheme_checked_syntax_e(int argc, Scheme_Object **argv)
 {
   if (!SCHEME_STXP(argv[0]))
     scheme_wrong_contract("syntax-e", "syntax?", 0, argc, argv);

--- a/racket/src/racket/src/syntax.c
+++ b/racket/src/racket/src/syntax.c
@@ -43,7 +43,7 @@ static Scheme_Object *syntax_p(int argc, Scheme_Object **argv);
 static Scheme_Object *syntax_to_datum(int argc, Scheme_Object **argv);
 static Scheme_Object *datum_to_syntax(int argc, Scheme_Object **argv);
 
-static Scheme_Object *syntax_e(int argc, Scheme_Object **argv);
+Scheme_Object *scheme_syntax_e(int argc, Scheme_Object **argv);
 static Scheme_Object *syntax_line(int argc, Scheme_Object **argv);
 static Scheme_Object *syntax_col(int argc, Scheme_Object **argv);
 static Scheme_Object *syntax_pos(int argc, Scheme_Object **argv);
@@ -107,7 +107,7 @@ void scheme_init_stx(Scheme_Startup_Env *env)
   ADD_FOLDING_PRIM("syntax->datum", syntax_to_datum, 1, 1, 1, env);
   ADD_IMMED_PRIM("datum->syntax", datum_to_syntax, 2, 5, env);
   
-  ADD_FOLDING_PRIM("syntax-e", syntax_e, 1, 1, 1, env);
+  ADD_FOLDING_PRIM("syntax-e", scheme_syntax_e, 1, 1, 1, env);
 
   ADD_FOLDING_PRIM("syntax-line"    , syntax_line   , 1, 1, 1, env);
   ADD_FOLDING_PRIM("syntax-column"  , syntax_col    , 1, 1, 1, env);
@@ -777,7 +777,7 @@ static Scheme_Object *datum_to_syntax(int argc, Scheme_Object **argv)
   return src;
 }
 
-static Scheme_Object *syntax_e(int argc, Scheme_Object **argv)
+Scheme_Object *scheme_syntax_e(int argc, Scheme_Object **argv)
 {
   if (!SCHEME_STXP(argv[0]))
     scheme_wrong_contract("syntax-e", "syntax?", 0, argc, argv);


### PR DESCRIPTION
This also makes `syntax_e` into `scheme_syntax_e` which is now exported by the
runtime.

There are a couple questions as FIXME in the code.